### PR TITLE
Fix the linker complaining about the lib being renamed

### DIFF
--- a/jsoncpp.rb
+++ b/jsoncpp.rb
@@ -13,11 +13,13 @@ class Jsoncpp < Formula
     gccversion = gccversion.delete("\n");
     # run the build
     system "scons platform=linux-gcc"
-    #install the libs
-    lib.install "libs/linux-gcc-#{gccversion}/libjson_linux-gcc-#{gccversion}_libmt.a" => "libjson.a", 
-    "libs/linux-gcc-#{gccversion}/libjson_linux-gcc-#{gccversion}_libmt.dylib" => "libjson.dylib"
+    # install the libs
+    lib.install "libs/linux-gcc-#{gccversion}/libjson_linux-gcc-#{gccversion}_libmt.a",
+                "libs/linux-gcc-#{gccversion}/libjson_linux-gcc-#{gccversion}_libmt.dylib"
+    lib.install_symlink lib/"libjson_linux-gcc-4.2.1_libmt.a"     => "libjsoncpp.a",
+                        lib/"libjson_linux-gcc-4.2.1_libmt.dylib" => "libjsoncpp.dylib"
     # install the headers
-    include.install "include/json" => "json"
+    include.install "include/json"
   end
 
   test do


### PR DESCRIPTION
If the .a and .dylib files are renamed, an executable linked with the renamed file still tries to find the library using the original name, and crashes.

With this PR, two variants are created:
- `libjson_linux-gcc-4.2.1_libmt.a`
- `libjson_linux-gcc-4.2.1_libmt.dylib`
- `libjsoncpp.a` (symlink to `libjson_linux-gcc-4.2.1_libmt.a`)
- `libjsoncpp.dylib` (symlink to `libjson_linux-gcc-4.2.1_libmt.dylib`)
